### PR TITLE
Add new options baseDir

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -123,6 +123,12 @@ when using the named-import form, the named identifiers must also be in this cas
 
 Its value should be given in the same format as `sassCase`.
 
+### `baseDir`
+
+This option identifies base directory for imports.
+
+Its value should be given as string `path`.
+
 ## Examples
 
 ### Basic examples

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ export default function({types: t}, opts) {
         changeCase[opts.sassCase] : sameCase;
     let outputCase = opts.outputCase ?
         changeCase[opts.outputCase] : sameCase;
+    let baseDir = opts.baseDir ?
+        opts.baseDir : "";
 
     let lookup = new VarLookup(sassCase, outputCase);
 
@@ -38,7 +40,7 @@ export default function({types: t}, opts) {
                 return;
             }
 
-            let absPath = resolveAbsPath(file.opts.filename, importPath);
+            let absPath = resolveAbsPath(resolve(file.opts.filename, baseDir), importPath);
             let specs = astPath.node.specifiers;
             let replace = [];
 


### PR DESCRIPTION
There were problems with metro bundler while working with the monorepository. "file.opts.filename" came as "/Users/username/Documents/project/**packages/native/packages/native**/src/styles/index.js" and the path was doubled.

In my case help `baseDir : "../../"`
```javascript
{
	"file where import scss": "packages/native/src/styles/index.js",
	"import scss": "import vars from '../../../shared/styles/_var.scss';"
}
```
```javascript
// baseDir: "../../"
{
	"file.opts.filename": '/Users/project/packages/native/packages/native/src/styles/index.js',
	"path.resolve(file.opts.filename, baseDir)": '/Users/project/packages/native/packages/native/src',
	absPath: '/Users/project/packages/shared/styles/_var.scss' // right path
}
```